### PR TITLE
Auth status check fix 2

### DIFF
--- a/scribble-app/package-lock.json
+++ b/scribble-app/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser": "^14.0.0",
         "@angular/platform-browser-dynamic": "^14.0.0",
         "@angular/router": "^14.0.0",
+        "buffer": "^6.0.3",
         "moment": "^2.29.4",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
@@ -3642,7 +3643,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3700,6 +3700,30 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/body-parser": {
@@ -3809,10 +3833,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -3829,7 +3852,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -6414,7 +6437,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14789,8 +14811,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",
@@ -14825,6 +14846,18 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "body-parser": {
@@ -14913,13 +14946,12 @@
       }
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -16787,8 +16819,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",

--- a/scribble-app/package.json
+++ b/scribble-app/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "^14.0.0",
     "@angular/platform-browser-dynamic": "^14.0.0",
     "@angular/router": "^14.0.0",
+    "buffer": "^6.0.3",
     "moment": "^2.29.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/scribble-app/src/app/services/auth/auth.service.ts
+++ b/scribble-app/src/app/services/auth/auth.service.ts
@@ -26,9 +26,22 @@ export class AuthService {
   }
 
   checkAuthStatus(): Observable<boolean> {
+    // Check if the app has already been initialized
+    const appInitialized = localStorage.getItem('app_load_status');
+    console.log(document.cookie);
+
+    if (!appInitialized) {
+      // First-time load: Do not make an API call
+      localStorage.setItem('app_load_status', 'true'); // Set the flag in localStorage
+      this.updateisLoggedInStatus(false); // Default to "not logged in"
+      return of(false); // Skip API call
+    }
+
+    // For subsequent loads or manual reloads, make the API call
     return this._http
       .get<IGenericResponse>(
-        this.apiGateWay + 'auth-service/api/v1/auth/is_loggedin'
+        this.apiGateWay + 'auth-service/api/v1/auth/is_loggedin',
+        { withCredentials: true } // Ensure cookies are sent with the request
       )
       .pipe(
         map((response) => {
@@ -110,6 +123,7 @@ export class AuthService {
   }
 
   logout(): Observable<IGenericResponse> {
+    localStorage.removeItem('app_load_status');
     return this._http
       .post(this.apiGateWay + 'auth-service/api/v1/auth/logout', {})
       .pipe(map((response) => response as IGenericResponse));

--- a/scribble-app/src/app/services/auth/auth.service.ts
+++ b/scribble-app/src/app/services/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { ILogin } from 'src/app/model/ILogin';
 import { ISignUpAndForgotPassword } from 'src/app/model/ISignUpAndForgotPassword';
 import { catchError, map } from 'rxjs/operators';
 import { Router } from '@angular/router';
+import { Buffer } from 'buffer';
 
 @Injectable({
   providedIn: 'root',
@@ -28,11 +29,13 @@ export class AuthService {
   checkAuthStatus(): Observable<boolean> {
     // Check if the app has already been initialized
     const appInitialized = localStorage.getItem('app_load_status');
-    console.log(document.cookie);
 
     if (!appInitialized) {
       // First-time load: Do not make an API call
-      localStorage.setItem('app_load_status', 'true'); // Set the flag in localStorage
+      localStorage.setItem(
+        'app_load_status',
+        Buffer.from('true').toString('base64')
+      ); // Set the flag in localStorage
       this.updateisLoggedInStatus(false); // Default to "not logged in"
       return of(false); // Skip API call
     }


### PR DESCRIPTION
### Issue:
- The user log in status check from the backend is triggered using the app initializer. 
- This meant that the api call was fired even on the login/signup page - which is the first page on which a user arrives on the app.
- Since there would be no http only cookies sent with this request, it would always fail throwing a 401 error(The cookies won't be present becase the user lands on the webapp for the first time)

### Solution
- Modified the `checkAuthStatus` method in the client side auth service to set a value in the local storage and NOT trigger the API call. 
- Along with the above change we are setting the value of the `isLoggedIn` observable as false - which is obvious, because if the user lands on the app for the first time, he obviously is NOT logged in. 
- So now if a user lands on the login page for the first time, the API is not fired instead a value is stored in the local storage indicating that the user has loaded the webapp atleast once on his browser.

Note:
1. Because of point 2 of the solution, if this value in the local storage is deleted manually, the route guards redirect the user to the login page because the check for the value fails and the the observable is set to false.
2. This was not a major issue which hampered the functionality of the app - rather it was done just to let go of the initial API failure on app load(for first time)
3. If in future this approach is to be reverted, then just revert back 2 commits.